### PR TITLE
Fix REGEX

### DIFF
--- a/lib/bitcoin.py
+++ b/lib/bitcoin.py
@@ -2,7 +2,7 @@ from Crypto.Hash import SHA256
 import re
 import math
 
-REGEX     = re.compile('\b[13][a-zA-Z1-9]{26,34}\b')
+REGEX     = re.compile(r'\b[13][a-zA-Z1-9]{26,34}\b')
 REGEX_ALL = re.compile('^[13][a-zA-Z1-9]{26,34}$')
 
 __b58chars = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'

--- a/lib/email_util.py
+++ b/lib/email_util.py
@@ -1,4 +1,4 @@
 import re
 
-REGEX     = re.compile('\b[a-zA-Z0-9_.+-]{1,50}@[a-zA-Z0-9-]{1,50}\.[a-zA-Z0-9-.]{1,50}[a-zA-Z0-9]\b')
+REGEX     = re.compile(r'\b[a-zA-Z0-9_.+-]{1,50}@[a-zA-Z0-9-]{1,50}\.[a-zA-Z0-9-.]{1,50}[a-zA-Z0-9]\b')
 REGEX_ALL = re.compile('^[a-zA-Z0-9_.+-]{1,50}@[a-zA-Z0-9-]{1,50}\.[a-zA-Z0-9-.]{1,50}[a-zA-Z0-9]$')


### PR DESCRIPTION
Regex missed an 'r', because python interpret \b as \x08 and it's why the regex for bitcoin and email didn't work.