### PR TITLE
Set privoxy to ipv4

### DIFF
--- a/scripts/create_privoxy_confs.sh
+++ b/scripts/create_privoxy_confs.sh
@@ -22,7 +22,7 @@ do
 	mkdir -p $LOGDIR
 	echo "forward-socks5t   /               127.0.0.1:$SOCKS_PORT ." > $CONF
 	echo "logdir $LOGDIR" >> $CONF
-	echo "listen-address  localhost:$LISTEN_PORT" >> $CONF
+	echo "listen-address  127.0.0.1:$LISTEN_PORT" >> $CONF
 	cat $ETCDIR/privoxy.config.default >> $CONF
 
 cat << EOF > $SERVICE_FILE


### PR DESCRIPTION
Changed it, because localhost can be assign to ipv4 and ipv6. If you have bot of them, by default, it will use ipv6, but we want to use ipv4.